### PR TITLE
added test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: test
+
+# Controls when the workflow will run
+on: [push]
+
+# Controls what will run
+jobs:
+  #workflow called build checks if project successfully builds
+  build:
+    runs-on: [ubuntu-latest]
+
+    steps:
+            # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+            - uses: actions/checkout@v2
+            # Setup JDK
+            - name: Set up JDK 11
+              uses: actions/setup-java@v1
+              with:
+                  java-version: 11
+            # Changes Gradle permissions and runs test
+            - name: Grant execute permission for gradlew
+              run: chmod +x gradlew
+            - name: Build with Gradle
+              run: ./gradlew test


### PR DESCRIPTION
@lucasliebe at the moment we setup the environment three times: For the build, for linting, for testing. We could setup the environment once and than execute all three. We have unlimited time, as it is a public repo, but the waiting time is annoying.