### PR TITLE
114 sensor data capture mode

### DIFF
--- a/app/src/main/java/sensors_in_paradise/sonar/GlobalValues.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/GlobalValues.kt
@@ -3,6 +3,7 @@ package sensors_in_paradise.sonar
 import android.Manifest
 import android.content.Context
 import android.os.Build
+import com.xsens.dot.android.sdk.models.XsensDotPayload
 import java.io.File
 
 class GlobalValues private constructor() {
@@ -10,6 +11,7 @@ class GlobalValues private constructor() {
         const val NULL_ACTIVITY = "null - activity"
         const val UNKNOWN_PERSON = "unknown"
         const val METADATA_JSON_FILENAME = "metadata.json"
+        const val MEASUREMENT_MODE = XsensDotPayload.PAYLOAD_TYPE_CUSTOM_MODE_4
         fun getSensorRecordingsBaseDir(context: Context): File {
             return context.getExternalFilesDir(null) ?: context.dataDir
         }

--- a/app/src/main/java/sensors_in_paradise/sonar/page2/LoggingManager.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/page2/LoggingManager.kt
@@ -12,6 +12,7 @@ import sensors_in_paradise.sonar.GlobalValues
 import sensors_in_paradise.sonar.R
 import sensors_in_paradise.sonar.XSENSArrayList
 import sensors_in_paradise.sonar.XSensDotMetadataStorage
+import sensors_in_paradise.sonar.util.PreferencesHelper
 import java.io.File
 import java.io.FileOutputStream
 import java.nio.file.Files
@@ -118,7 +119,7 @@ class LoggingManager(
     private fun getRecordingFileDir(time: LocalDateTime): File {
         val timeStr = time.toInstant(ZoneOffset.UTC).toEpochMilli().toString()
 
-        return GlobalValues.getSensorRecordingsBaseDir(context).resolve("ML Prototype Recordings")
+        return GlobalValues.getSensorRecordingsBaseDir(context).resolve(PreferencesHelper.getRecordingsSubDir(context))
             .resolve(timeStr)
     }
 
@@ -160,7 +161,7 @@ class LoggingManager(
         tempRecordingMap[recordingsKey] = arrayListOf()
         recordingStartTime = System.currentTimeMillis()
         for (device in devices.getConnected()) {
-            device.measurementMode = XsensDotPayload.PAYLOAD_TYPE_COMPLETE_QUATERNION
+            device.measurementMode = GlobalValues.MEASUREMENT_MODE
             device.startMeasuring()
             val file = getNewUnlabelledTempFile(fileDir, device.address)
 
@@ -169,7 +170,7 @@ class LoggingManager(
                 XsensDotLogger(
                     this.context,
                     XsensDotLogger.TYPE_CSV,
-                    XsensDotPayload.PAYLOAD_TYPE_COMPLETE_QUATERNION,
+                    GlobalValues.MEASUREMENT_MODE,
                     file.absolutePath,
                     device.address,
                     "1",

--- a/app/src/main/java/sensors_in_paradise/sonar/page2/LoggingManager.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/page2/LoggingManager.kt
@@ -6,7 +6,6 @@ import android.os.SystemClock
 import android.widget.*
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.button.MaterialButton
-import com.xsens.dot.android.sdk.models.XsensDotPayload
 import com.xsens.dot.android.sdk.utils.XsensDotLogger
 import sensors_in_paradise.sonar.GlobalValues
 import sensors_in_paradise.sonar.R
@@ -28,7 +27,7 @@ class LoggingManager(
     private val timer: Chronometer,
     private val labelTV: TextView,
     private val personTV: TextView,
-    private val activitiesRV: RecyclerView
+    activitiesRV: RecyclerView
 ) {
 
     val xsLoggers: ArrayList<XsensDotLogger> = ArrayList()

--- a/app/src/main/java/sensors_in_paradise/sonar/util/PreferencesHelper.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/util/PreferencesHelper.kt
@@ -3,6 +3,7 @@ package sensors_in_paradise.sonar.util
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.preference.PreferenceManager
+import sensors_in_paradise.sonar.R
 
 class PreferencesHelper private constructor() {
     companion object {
@@ -17,6 +18,9 @@ class PreferencesHelper private constructor() {
         }
         fun shouldShowToastsVerbose(context: Context): Boolean {
             return getSharedPreferences(context).getBoolean("verboseToasts", false)
+        }
+        fun getRecordingsSubDir(context: Context): String {
+            return getSharedPreferences(context).getString("recordingsSubDir", context.getString(R.string.default_recordings_subdir))!!
         }
     }
 }

--- a/app/src/main/java/sensors_in_paradise/sonar/util/PreferencesHelper.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/util/PreferencesHelper.kt
@@ -10,17 +10,24 @@ class PreferencesHelper private constructor() {
         fun getSharedPreferences(context: Context): SharedPreferences {
             return PreferenceManager.getDefaultSharedPreferences(context)
         }
+
         fun shouldUseDarkMode(context: Context): Boolean {
             return getSharedPreferences(context).getBoolean("darkMode", false)
         }
+
         fun shouldFollowSystemTheme(context: Context): Boolean {
             return !getSharedPreferences(context).getBoolean("unfollowSystemTheme", false)
         }
+
         fun shouldShowToastsVerbose(context: Context): Boolean {
             return getSharedPreferences(context).getBoolean("verboseToasts", false)
         }
+
         fun getRecordingsSubDir(context: Context): String {
-            return getSharedPreferences(context).getString("recordingsSubDir", context.getString(R.string.default_recordings_subdir))!!
+            return getSharedPreferences(context).getString(
+                "recordingsSubDir",
+                context.getString(R.string.default_recordings_subdir)
+            )!!
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="attachment_summary_on">Automatically download attachments for incoming emails
     </string>
     <string name="attachment_summary_off">Only download attachments when manually requested</string>
+    <string name="default_recordings_subdir">ML Prototype Recordings</string>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,4 +1,5 @@
-<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <!-- <PreferenceCategory app:title="@string/messages_header">
 
@@ -35,5 +36,15 @@
             app:title="Verbose Toast logging"
             app:defaultValue="false"
             app:summary="Show semi-important Toasts for debugging"/>
+    </PreferenceCategory>
+    <PreferenceCategory app:title="Data recording options">
+
+        <EditTextPreference
+            android:defaultValue="@string/default_recordings_subdir"
+            android:key="recordingsSubDir"
+            android:selectAllOnFocus="false"
+            android:singleLine="true"
+            android:title="Recordings subdirectory"
+            android:summary="Choose the name of the subdirectory in which recordings should be stored. This directory will then also be mirrored in the cloud on upload."/>
     </PreferenceCategory>
 </PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip


### PR DESCRIPTION
Closes #114 

We are now using this measurement mode:
![image](https://user-images.githubusercontent.com/29177177/156600389-7363bccc-65c8-4350-bc92-98ff97cee4f4.png)

I also added a preference to change the subdirectory in which recordings are stored. With this, we can test recording in our app during the dev process without uploading those recordings into our main "production" recordings dir in the cloud.