### PR TITLE
Bugfix synchronized check crash

### DIFF
--- a/app/src/main/java/sensors_in_paradise/sonar/page2/Recording.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/page2/Recording.kt
@@ -4,7 +4,11 @@ import sensors_in_paradise.sonar.GlobalValues
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
+import kotlin.math.floor
 import kotlin.random.Random
+
+const val XSENS_HEADER_SIZE = 9
+const val XSENS_EMPTY_FILE_SIZE = 430
 
 open class Recording(val dir: File, val metadataStorage: RecordingMetadataStorage) {
     constructor(dir: File) : this(
@@ -51,7 +55,13 @@ open class Recording(val dir: File, val metadataStorage: RecordingMetadataStorag
             val firstFile = childCSVs[0]
 
             val lineNumber = getAbsoluteLineNumber(firstFile)
-            val randomLine = Random.nextInt(headerSize + margin, lineNumber - margin)
+            val timesteps = lineNumber - XSENS_HEADER_SIZE
+
+            val margin = floor(timesteps * 0.2).toInt()
+            val lineFrom = XSENS_HEADER_SIZE + margin
+            val lineTo = lineNumber - margin
+            // End is exclusive, so +1 on last line
+            val randomLine = Random.nextInt(lineFrom, lineTo + 1)
             val timestamp = getTimeStampAtLine(firstFile, randomLine)
 
             assert(timestamp != "") { "No initial timestamp could be found." }

--- a/app/src/main/java/sensors_in_paradise/sonar/uploader/OwnCloudRecordingsUploader.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/uploader/OwnCloudRecordingsUploader.kt
@@ -47,7 +47,7 @@ class OwnCloudRecordingsUploader(activity: Activity, val recordingsManager: Reco
 
     fun synchronize() {
         for (recordingUiItem in recordingUiItems) {
-            if (recordingUiItem.areFilesValid) {
+            if (recordingUiItem.isValid) {
                 uploadRecording(recordingUiItem)
             }
         }


### PR DESCRIPTION
The issue why the app crashed today is, that the randomly generated line number for the synchronization check was out of bounds of that file. (because the first file, which is read to get the timestamp from a specific line, was empty)

To fix this, I did the following:
- the selected margin in `areFilesSynchronized` is now selected based on the available number of lines -> it shouldnt fail for very short recordings
- the synchronization check is only executed when no file is empty (then it is unnecessary anyway)

Additionally I refactored the code a bit to - instead of multiple bools / functions - we have an enum which represents the state of a recording (this simplifies conditional view rendering imho)