### PR TITLE
Stop recording on destroy

### DIFF
--- a/app/src/main/java/sensors_in_paradise/sonar/MainActivity.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/MainActivity.kt
@@ -85,7 +85,7 @@ class MainActivity : AppCompatActivity(), TabLayout.OnTabSelectedListener {
     }
 
     override fun onDestroy() {
-        pageHandlers.forEach { handler -> handler.activityDestroyed() }
+        pageHandlers.forEach { handler -> handler.activityWillDestroy() }
 
         super.onDestroy()
     }

--- a/app/src/main/java/sensors_in_paradise/sonar/MainActivity.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/MainActivity.kt
@@ -84,6 +84,12 @@ class MainActivity : AppCompatActivity(), TabLayout.OnTabSelectedListener {
         }
     }
 
+    override fun onDestroy() {
+        pageHandlers.forEach { handler -> handler.activityDestroyed() }
+
+        super.onDestroy()
+    }
+
     private fun initClickListeners() {
         tabLayout.addOnTabSelectedListener(this)
     }

--- a/app/src/main/java/sensors_in_paradise/sonar/PageInterface.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/PageInterface.kt
@@ -9,5 +9,5 @@ interface PageInterface {
     @UiThread
     fun activityResumed()
     @UiThread
-    fun activityDestroyed()
+    fun activityWillDestroy()
 }

--- a/app/src/main/java/sensors_in_paradise/sonar/PageInterface.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/PageInterface.kt
@@ -8,4 +8,6 @@ interface PageInterface {
     fun activityCreated(activity: Activity)
     @UiThread
     fun activityResumed()
+    @UiThread
+    fun activityDestroyed()
 }

--- a/app/src/main/java/sensors_in_paradise/sonar/PermissionsHandler.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/PermissionsHandler.kt
@@ -30,7 +30,7 @@ class PermissionsHandler(private val requestPermissionLauncher: ActivityResultLa
         }
     }
 
-    override fun activityDestroyed() {
+    override fun activityWillDestroy() {
         // Nothing to do
     }
 }

--- a/app/src/main/java/sensors_in_paradise/sonar/PermissionsHandler.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/PermissionsHandler.kt
@@ -29,4 +29,8 @@ class PermissionsHandler(private val requestPermissionLauncher: ActivityResultLa
             )
         }
     }
+
+    override fun activityDestroyed() {
+        // Nothing to do
+    }
 }

--- a/app/src/main/java/sensors_in_paradise/sonar/page1/Page1Handler.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/page1/Page1Handler.kt
@@ -166,7 +166,7 @@ class Page1Handler(private val scannedDevices: XSENSArrayList) :
         }
     }
 
-    override fun activityDestroyed() {
+    override fun activityWillDestroy() {
         // Nothing to do
     }
 

--- a/app/src/main/java/sensors_in_paradise/sonar/page1/Page1Handler.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/page1/Page1Handler.kt
@@ -165,6 +165,11 @@ class Page1Handler(private val scannedDevices: XSENSArrayList) :
             }
         }
     }
+
+    override fun activityDestroyed() {
+        // Nothing to do
+    }
+
     private var mXsScanner: XsensDotScanner? = null
     private fun initXsScanner() {
         mXsScanner = XsensDotScanner(context, this)

--- a/app/src/main/java/sensors_in_paradise/sonar/page2/LoggingManager.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/page2/LoggingManager.kt
@@ -183,7 +183,8 @@ class LoggingManager(
     }
 
     private fun stopLogging() {
-        assert(activeRecording != null)
+        if (activeRecording == null) return
+
         val activeRecording = activeRecording!!
         activeRecording.stop()
 
@@ -197,6 +198,20 @@ class LoggingManager(
             this.activeRecording = null
             labelTV.text = ""
         }
+    }
+
+    /**
+     * Stops and saves the current recording immediately. Different to `stopLogging` the user is not
+     * asked for input if values are missing.
+     */
+    fun stopLoggingImmediately() {
+        if (!isLabelSelected()) {
+            updateSelectedLabel(GlobalValues.NULL_ACTIVITY, 0)
+        }
+        if (!isPersonSelected()) {
+            updateSelectedPerson(GlobalValues.UNKNOWN_PERSON)
+        }
+        stopLogging()
     }
 
     private fun resolveMissingFields(onAllResolved: () -> Unit) {

--- a/app/src/main/java/sensors_in_paradise/sonar/page2/LoggingManager.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/page2/LoggingManager.kt
@@ -140,7 +140,7 @@ class LoggingManager(
             Toast.makeText(
                 context,
                 "Only $numConnected out of $VALID_SENSOR_NUM devices are connected!",
-                Toast.LENGTH_SHORT
+                Toast.LENGTH_LONG
             ).show()
         }
         return true

--- a/app/src/main/java/sensors_in_paradise/sonar/page2/Page2Handler.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/page2/Page2Handler.kt
@@ -78,7 +78,7 @@ class Page2Handler(
     override fun activityResumed() {
     }
 
-    override fun activityDestroyed() {
+    override fun activityWillDestroy() {
         loggingManager.stopLoggingImmediately()
     }
 

--- a/app/src/main/java/sensors_in_paradise/sonar/page2/Page2Handler.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/page2/Page2Handler.kt
@@ -78,6 +78,10 @@ class Page2Handler(
     override fun activityResumed() {
     }
 
+    override fun activityDestroyed() {
+        loggingManager.stopLoggingImmediately()
+    }
+
     override fun onConnectedDevicesChanged(deviceAddress: String, connected: Boolean) {
         numConnectedDevices = devices.getConnected().size
         loggingManager.handleConnectionStateChange(deviceAddress, connected)

--- a/app/src/main/java/sensors_in_paradise/sonar/page3/Page3Handler.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/page3/Page3Handler.kt
@@ -214,6 +214,10 @@ class Page3Handler(private val devices: XSENSArrayList) : PageInterface, Connect
     override fun activityResumed() {
     }
 
+    override fun activityDestroyed() {
+        // Nothing to do
+    }
+
     override fun onConnectedDevicesChanged(deviceAddress: String, connected: Boolean) {
 
         numConnectedDevices = devices.getConnected().size
@@ -235,6 +239,6 @@ class Page3Handler(private val devices: XSENSArrayList) : PageInterface, Connect
     }
 
     override fun onXsensDotOutputRateUpdate(deviceAddress: String, outputRate: Int) {
-        // TODO("Not yet implemented")
+        // Nothing to do (?)
     }
 }

--- a/app/src/main/java/sensors_in_paradise/sonar/page3/Page3Handler.kt
+++ b/app/src/main/java/sensors_in_paradise/sonar/page3/Page3Handler.kt
@@ -214,7 +214,7 @@ class Page3Handler(private val devices: XSENSArrayList) : PageInterface, Connect
     override fun activityResumed() {
     }
 
-    override fun activityDestroyed() {
+    override fun activityWillDestroy() {
         // Nothing to do
     }
 


### PR DESCRIPTION
Stops the recording when the activity gets destroyed (e.g. on theme change) to not loose all the recording data.

Also shows the device connection toast a bit longer when starting a recording with not enough devices connected.

closes #135 